### PR TITLE
Add enums and skeleton for opaque RDMA process group handle

### DIFF
--- a/pg.c
+++ b/pg.c
@@ -1,0 +1,42 @@
+#include "pg.h"
+
+/* Forward declarations for RDMA structures to avoid external dependencies */
+struct ibv_context;
+struct ibv_pd;
+struct ibv_cq;
+struct ibv_qp;
+struct ibv_mr;
+
+struct pg_handle {
+    struct ibv_context *ctx;          /* device context */
+    struct ibv_pd *pd;                /* protection domain */
+    struct ibv_cq *cq;                /* completion queue */
+    struct ibv_qp *qps[2];            /* two queue pairs */
+    uint32_t max_inline_data;         /* inline threshold */
+
+    int rank;                         /* rank in communicator */
+    int world_size;                   /* total participants */
+    int left_index;                   /* neighbor to the left */
+    int right_index;                  /* neighbor to the right */
+
+    int bootstrap_socks[2];           /* TCP bootstrap sockets */
+
+    struct ibv_mr *data_mrs[2];       /* exposed data windows */
+    struct ibv_mr *ctrl_mr;           /* small control window */
+
+    uint32_t neighbor_rkeys[2];       /* neighbors' rkeys */
+    uintptr_t neighbor_base_addrs[2]; /* neighbors' base addresses */
+
+    size_t chunk_bytes;               /* pipeline chunk size */
+    int inflight_limit;               /* maximum inflight operations */
+
+    int rx_credits[2];                /* receive credit counters */
+};
+
+int pg_rank(const pg_handle *handle) {
+    return handle ? handle->rank : -1;
+}
+
+int pg_world_size(const pg_handle *handle) {
+    return handle ? handle->world_size : -1;
+}

--- a/pg.h
+++ b/pg.h
@@ -1,0 +1,30 @@
+#ifndef PG_H
+#define PG_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Datatype identifiers */
+typedef enum {
+    DT_INT32,
+    DT_DOUBLE
+} DATATYPE;
+
+/* Supported reduction operations */
+typedef enum {
+    OP_SUM,
+    OP_PROD
+} OPERATION;
+
+/* Forward declaration of the internal handle */
+typedef struct pg_handle pg_handle;
+
+/* Default pipeline thresholds */
+#define PG_DEFAULT_CHUNK_BYTES 4096
+#define PG_DEFAULT_INFLIGHT_LIMIT 4
+
+/* Accessors */
+int pg_rank(const pg_handle *handle);
+int pg_world_size(const pg_handle *handle);
+
+#endif /* PG_H */


### PR DESCRIPTION
## Summary
- Define DATATYPE and OPERATION enums for public API
- Add opaque `pg_handle` declaration and accessor prototypes
- Implement internal `pg_handle` struct with RDMA resource placeholders and basic rank/size getters