### PR TITLE
Add server list parser with rank discovery and unit tests

### DIFF
--- a/serverlist.c
+++ b/serverlist.c
@@ -1,0 +1,71 @@
+#include "serverlist.h"
+
+#include <ctype.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <string.h>
+
+int parse_server_list(const char *serverlist,
+                      const char *my_hostname,
+                      char ***hosts_out,
+                      size_t *num_hosts_out,
+                      size_t *my_index_out) {
+    if (!serverlist || !my_hostname || !hosts_out || !num_hosts_out || !my_index_out) {
+        return -1;
+    }
+
+    char **hosts = NULL;
+    size_t count = 0;
+    ssize_t my_rank = -1;
+
+    const char *p = serverlist;
+    while (*p) {
+        while (isspace((unsigned char)*p)) p++;
+        if (!*p) break;
+        const char *start = p;
+        while (*p && !isspace((unsigned char)*p)) p++;
+        size_t len = (size_t)(p - start);
+        char *host = malloc(len + 1);
+        if (!host) {
+            free_host_list(hosts, count);
+            return -1;
+        }
+        memcpy(host, start, len);
+        host[len] = '\0';
+        char **tmp = realloc(hosts, sizeof(*hosts) * (count + 1));
+        if (!tmp) {
+            free(host);
+            free_host_list(hosts, count);
+            return -1;
+        }
+        hosts = tmp;
+        hosts[count] = host;
+
+        size_t my_len = strlen(my_hostname);
+        if (my_rank == -1 &&
+            ((my_len >= len && strncmp(my_hostname, host, len) == 0) ||
+             (len >= my_len && strncmp(host, my_hostname, my_len) == 0))) {
+            my_rank = (ssize_t)count;
+        }
+
+        count++;
+    }
+
+    if (my_rank == -1) {
+        free_host_list(hosts, count);
+        return -1;
+    }
+
+    *hosts_out = hosts;
+    *num_hosts_out = count;
+    *my_index_out = (size_t)my_rank;
+    return 0;
+}
+
+void free_host_list(char **hosts, size_t count) {
+    if (!hosts) return;
+    for (size_t i = 0; i < count; ++i) {
+        free(hosts[i]);
+    }
+    free(hosts);
+}

--- a/serverlist.h
+++ b/serverlist.h
@@ -1,0 +1,27 @@
+#ifndef SERVERLIST_H
+#define SERVERLIST_H
+
+#include <stddef.h>
+
+/*
+ * Parse a whitespace-separated list of hostnames and determine the caller's rank.
+ *
+ * serverlist:    input string containing hostnames separated by any whitespace.
+ * my_hostname:   the hostname of the current process.
+ * hosts_out:     on success, will point to an array of strings containing the
+ *                hostnames. The caller must free this array with free_host_list().
+ * num_hosts_out: on success, number of hosts in the list.
+ * my_index_out:  on success, the index of my_hostname within the list.
+ *
+ * Returns 0 on success, -1 if my_hostname is not found or on allocation error.
+ */
+int parse_server_list(const char *serverlist,
+                      const char *my_hostname,
+                      char ***hosts_out,
+                      size_t *num_hosts_out,
+                      size_t *my_index_out);
+
+/* Free the array returned by parse_server_list. */
+void free_host_list(char **hosts, size_t count);
+
+#endif /* SERVERLIST_H */

--- a/serverlist_test.c
+++ b/serverlist_test.c
@@ -1,0 +1,43 @@
+#include "serverlist.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+static void test_single_host(void) {
+    const char *servers = "host1";
+    char **hosts = NULL;
+    size_t count = 0, my_index = 0;
+    int rc = parse_server_list(servers, "host1", &hosts, &count, &my_index);
+    assert(rc == 0);
+    assert(count == 1);
+    assert(my_index == 0);
+    free_host_list(hosts, count);
+}
+
+static void test_four_hosts(void) {
+    const char *servers = "host1 host2\n   host3\thost4";
+    char **hosts = NULL;
+    size_t count = 0, my_index = 0;
+    int rc = parse_server_list(servers, "host3.example.com", &hosts, &count, &my_index);
+    assert(rc == 0);
+    assert(count == 4);
+    assert(my_index == 2);
+    free_host_list(hosts, count);
+}
+
+static void test_host_not_found(void) {
+    const char *servers = "host1 host2";
+    char **hosts = NULL;
+    size_t count = 0, my_index = 0;
+    int rc = parse_server_list(servers, "host3", &hosts, &count, &my_index);
+    assert(rc == -1);
+    assert(hosts == NULL);
+}
+
+int main(void) {
+    test_single_host();
+    test_four_hosts();
+    test_host_not_found();
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add pure server list parser that returns host vector and my rank with prefix matching
- Provide helper to free parsed host list
- Include unit-style tests for single host, four hosts, and host not found

## Testing
- `gcc -Wall -Wextra -std=c11 serverlist.c serverlist_test.c -o serverlist_test && ./serverlist_test`


------
https://chatgpt.com/codex/tasks/task_e_68a8be39cbbc8332ab7921e7f5d67f6e