### PR TITLE
Add non-blocking dual-socket bootstrap

### DIFF
--- a/bootstrap.c
+++ b/bootstrap.c
@@ -1,0 +1,188 @@
+#define _POSIX_C_SOURCE 200112L
+#include "bootstrap.h"
+#include "ring.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+static int set_nonblocking(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) return -1;
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) return -1;
+    return 0;
+}
+
+static int set_blocking(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) return -1;
+    if (fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) < 0) return -1;
+    return 0;
+}
+
+int bootstrap_ring(const char **hosts, size_t count, size_t my_index,
+                   int port_base, int timeout_ms,
+                   int *fd_from_left, int *fd_to_right) {
+    if (!hosts || count == 0 || my_index >= count || !fd_from_left || !fd_to_right)
+        return -1;
+
+    int listen_fd = -1;
+    int connect_fd = -1;
+    int left_fd = -1;
+    int right_fd = -1;
+
+    int rc = -1; /* default to failure */
+
+    int right_index = right_of((int)my_index, (int)count);
+
+    char portstr[16];
+    struct addrinfo hints, *ai = NULL, *p;
+
+    /* setup listening socket */
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+    snprintf(portstr, sizeof(portstr), "%d", port_base + (int)my_index);
+    if (getaddrinfo(NULL, portstr, &hints, &ai) != 0)
+        goto out;
+    for (p = ai; p; p = p->ai_next) {
+        listen_fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+        if (listen_fd < 0)
+            continue;
+        int yes = 1;
+        setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+        if (set_nonblocking(listen_fd) < 0) {
+            close(listen_fd);
+            listen_fd = -1;
+            continue;
+        }
+        if (bind(listen_fd, p->ai_addr, p->ai_addrlen) == 0 &&
+            listen(listen_fd, 1) == 0)
+            break;
+        close(listen_fd);
+        listen_fd = -1;
+    }
+    freeaddrinfo(ai);
+    ai = NULL;
+    if (listen_fd < 0)
+        goto out;
+
+    /* setup outgoing connection */
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    snprintf(portstr, sizeof(portstr), "%d", port_base + right_index);
+    if (getaddrinfo(hosts[right_index], portstr, &hints, &ai) != 0)
+        goto out;
+    for (p = ai; p; p = p->ai_next) {
+        connect_fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+        if (connect_fd < 0)
+            continue;
+        if (set_nonblocking(connect_fd) < 0) {
+            close(connect_fd);
+            connect_fd = -1;
+            continue;
+        }
+        if (connect(connect_fd, p->ai_addr, p->ai_addrlen) == 0) {
+            right_fd = connect_fd;
+        } else if (errno == EINPROGRESS) {
+            right_fd = -1; /* will complete later */
+        } else {
+            close(connect_fd);
+            connect_fd = -1;
+            continue;
+        }
+        break;
+    }
+    freeaddrinfo(ai);
+    ai = NULL;
+    if (connect_fd < 0)
+        goto out;
+    if (right_fd >= 0) {
+        /* connection completed immediately */
+        connect_fd = right_fd;
+    }
+
+    /* poll loop */
+    struct pollfd pfds[2];
+    struct timespec start, now;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    int remaining = timeout_ms;
+
+    while ((left_fd < 0 || right_fd < 0) && remaining > 0) {
+        int idx = 0;
+        if (left_fd < 0) {
+            pfds[idx].fd = listen_fd;
+            pfds[idx].events = POLLIN;
+            pfds[idx].revents = 0;
+            idx++;
+        }
+        if (right_fd < 0) {
+            pfds[idx].fd = connect_fd;
+            pfds[idx].events = POLLOUT;
+            pfds[idx].revents = 0;
+            idx++;
+        }
+        int prc = poll(pfds, idx, remaining);
+        if (prc < 0)
+            goto out;
+        if (prc == 0)
+            break; /* timeout */
+
+        int offset = 0;
+        if (left_fd < 0 && pfds[offset].fd == listen_fd) {
+            if (pfds[offset].revents & POLLIN) {
+                left_fd = accept(listen_fd, NULL, NULL);
+                if (left_fd >= 0) {
+                    set_blocking(left_fd);
+                    close(listen_fd);
+                } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                    goto out;
+                }
+            }
+            offset++;
+        }
+        if (right_fd < 0 && pfds[offset].fd == connect_fd) {
+            if (pfds[offset].revents & (POLLOUT | POLLERR | POLLHUP)) {
+                int err = 0;
+                socklen_t len = sizeof(err);
+                if (getsockopt(connect_fd, SOL_SOCKET, SO_ERROR, &err, &len) < 0 || err != 0) {
+                    goto out;
+                }
+                right_fd = connect_fd;
+                set_blocking(right_fd);
+            }
+        }
+
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        long elapsed = (now.tv_sec - start.tv_sec) * 1000L +
+                       (now.tv_nsec - start.tv_nsec) / 1000000L;
+        remaining = timeout_ms - (int)elapsed;
+    }
+
+    if (left_fd < 0 || right_fd < 0)
+        goto out;
+
+    *fd_from_left = left_fd;
+    *fd_to_right = right_fd;
+    rc = 0;
+
+out:
+    if (rc != 0) {
+        if (left_fd >= 0) close(left_fd);
+        if (right_fd >= 0) close(right_fd);
+    }
+    if (listen_fd >= 0) close(listen_fd);
+    if (connect_fd >= 0 && connect_fd != right_fd) close(connect_fd);
+    return rc;
+}
+

--- a/bootstrap.h
+++ b/bootstrap.h
@@ -1,0 +1,23 @@
+#ifndef BOOTSTRAP_H
+#define BOOTSTRAP_H
+
+#include <stddef.h>
+
+/*
+ * Establish a pair of TCP connections forming a ring.
+ *
+ * hosts: array of hostnames of size count.
+ * count: total number of hosts.
+ * my_index: index of the current host within the hosts array.
+ * port_base: base port; each host listens on port_base + its index.
+ * timeout_ms: maximum time to wait for connections.
+ * fd_from_left: on success, connected socket from left neighbor.
+ * fd_to_right:  on success, connected socket to right neighbor.
+ *
+ * Returns 0 on success, -1 on failure (with resources cleaned up).
+ */
+int bootstrap_ring(const char **hosts, size_t count, size_t my_index,
+                   int port_base, int timeout_ms,
+                   int *fd_from_left, int *fd_to_right);
+
+#endif /* BOOTSTRAP_H */

--- a/bootstrap_test.c
+++ b/bootstrap_test.c
@@ -1,0 +1,41 @@
+#include "bootstrap.h"
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+int main(void) {
+    const char *hosts[2] = {"127.0.0.1", "127.0.0.1"};
+    const int base_port = 40000;
+    int fd_left = -1, fd_right = -1;
+    pid_t pid = fork();
+    if (pid < 0) return 1;
+
+    if (pid == 0) {
+        /* child: rank 1 */
+        if (bootstrap_ring(hosts, 2, 1, base_port, 5000, &fd_left, &fd_right) != 0)
+            _exit(1);
+        char ch;
+        if (read(fd_left, &ch, 1) != 1) _exit(1);
+        assert(ch == 'a');
+        if (write(fd_right, "b", 1) != 1) _exit(1);
+        close(fd_left);
+        close(fd_right);
+        _exit(0);
+    } else {
+        /* parent: rank 0 */
+        if (bootstrap_ring(hosts, 2, 0, base_port, 5000, &fd_left, &fd_right) != 0)
+            return 1;
+        if (write(fd_right, "a", 1) != 1) return 1;
+        char ch;
+        if (read(fd_left, &ch, 1) != 1) return 1;
+        assert(ch == 'b');
+        close(fd_left);
+        close(fd_right);
+        int status = 0;
+        waitpid(pid, &status, 0);
+        assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+        printf("Bootstrap test passed\n");
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `bootstrap_ring` to establish left/right TCP connections with non-blocking sockets and timeout
- test dual-socket bootstrap by forking two ranks and exchanging bytes

## Testing
- `gcc -Wall -Wextra -std=c99 ring.c ring_test.c -o ring_test && ./ring_test`
- `gcc -Wall -Wextra -std=c99 serverlist.c serverlist_test.c -o serverlist_test && ./serverlist_test`
- `gcc -Wall -Wextra -std=c99 bootstrap.c ring.c bootstrap_test.c -o bootstrap_test && ./bootstrap_test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c161ea288332a64d2782d1880478