### PR TITLE
Add minimal RDMA verbs resource setup

### DIFF
--- a/pg.c
+++ b/pg.c
@@ -1,11 +1,8 @@
-#include "pg.h"
+#include <stdlib.h>
+#include <infiniband/verbs.h>
 
-/* Forward declarations for RDMA structures to avoid external dependencies */
-struct ibv_context;
-struct ibv_pd;
-struct ibv_cq;
-struct ibv_qp;
-struct ibv_mr;
+#include "pg.h"
+#include "ring.h"
 
 struct pg_handle {
     struct ibv_context *ctx;          /* device context */
@@ -39,4 +36,97 @@ int pg_rank(const pg_handle *handle) {
 
 int pg_world_size(const pg_handle *handle) {
     return handle ? handle->world_size : -1;
+}
+
+pg_handle *pg_create(int rank, int world_size, size_t chunk_bytes,
+                     int inflight_limit) {
+    pg_handle *handle = calloc(1, sizeof(*handle));
+    if (!handle)
+        return NULL;
+
+    handle->rank = rank;
+    handle->world_size = world_size;
+    handle->left_index = left_of(rank, world_size);
+    handle->right_index = right_of(rank, world_size);
+    handle->chunk_bytes = chunk_bytes ? chunk_bytes : PG_DEFAULT_CHUNK_BYTES;
+    handle->inflight_limit = inflight_limit > 0 ? inflight_limit
+                                                : PG_DEFAULT_INFLIGHT_LIMIT;
+
+    struct ibv_device **dev_list = ibv_get_device_list(NULL);
+    if (!dev_list)
+        goto err_free;
+
+    handle->ctx = ibv_open_device(dev_list[0]);
+    ibv_free_device_list(dev_list);
+    if (!handle->ctx)
+        goto err_free;
+
+    handle->pd = ibv_alloc_pd(handle->ctx);
+    if (!handle->pd)
+        goto err_ctx;
+
+    int cq_entries = 1 + handle->inflight_limit * 2;
+    handle->cq = ibv_create_cq(handle->ctx, cq_entries, NULL, NULL, 0);
+    if (!handle->cq)
+        goto err_pd;
+
+    struct ibv_qp_init_attr qp_attr = {
+        .send_cq = handle->cq,
+        .recv_cq = handle->cq,
+        .cap = {
+            .max_send_wr = handle->inflight_limit + 1,
+            .max_recv_wr = handle->inflight_limit + 1,
+            .max_send_sge = 1,
+            .max_recv_sge = 1,
+            .max_inline_data = 0,
+        },
+        .qp_type = IBV_QPT_RC,
+        .sq_sig_all = 0,
+    };
+
+    for (int i = 0; i < 2; ++i) {
+        handle->qps[i] = ibv_create_qp(handle->pd, &qp_attr);
+        if (!handle->qps[i]) {
+            for (int j = 0; j < i; ++j)
+                ibv_destroy_qp(handle->qps[j]);
+            goto err_cq;
+        }
+    }
+
+    struct ibv_qp_attr tmp_attr;
+    struct ibv_qp_init_attr tmp_init;
+    if (ibv_query_qp(handle->qps[0], &tmp_attr, IBV_QP_CAP, &tmp_init))
+        goto err_qp;
+    handle->max_inline_data = tmp_init.cap.max_inline_data;
+
+    return handle;
+
+err_qp:
+    for (int i = 0; i < 2; ++i)
+        if (handle->qps[i])
+            ibv_destroy_qp(handle->qps[i]);
+err_cq:
+    ibv_destroy_cq(handle->cq);
+err_pd:
+    ibv_dealloc_pd(handle->pd);
+err_ctx:
+    ibv_close_device(handle->ctx);
+err_free:
+    free(handle);
+    return NULL;
+}
+
+void pg_destroy(pg_handle *handle) {
+    if (!handle)
+        return;
+    for (int i = 0; i < 2; ++i)
+        if (handle->qps[i])
+            ibv_destroy_qp(handle->qps[i]);
+    if (handle->cq)
+        ibv_destroy_cq(handle->cq);
+    if (handle->pd)
+        ibv_dealloc_pd(handle->pd);
+    if (handle->ctx)
+        ibv_close_device(handle->ctx);
+    free(handle);
 }

--- a/pg.h
+++ b/pg.h
@@ -27,4 +27,9 @@ typedef struct pg_handle pg_handle;
 int pg_rank(const pg_handle *handle);
 int pg_world_size(const pg_handle *handle);
 
+/* Create and destroy a process group handle */
+pg_handle *pg_create(int rank, int world_size, size_t chunk_bytes,
+                     int inflight_limit);
+void pg_destroy(pg_handle *handle);
+
 #endif /* PG_H */

--- a/pg.h
+++ b/pg.h
@@ -32,4 +32,14 @@ pg_handle *pg_create(int rank, int world_size, size_t chunk_bytes,
                      int inflight_limit);
 void pg_destroy(pg_handle *handle);
 
+/* QP bootstrap information exchanged with neighbors */
+typedef struct {
+    uint32_t qpn;
+    uint16_t lid;      /* 0 when using gid */
+    uint8_t gid[16];   /* all zeros when using lid */
+} qp_boot;
+
+/* Transition both QPs to RTS using neighbor bootstrap info */
+int pg_qps_to_rts(pg_handle *handle, const qp_boot boots[2]);
+
 #endif /* PG_H */

--- a/pg.h
+++ b/pg.h
@@ -42,4 +42,8 @@ typedef struct {
 /* Transition both QPs to RTS using neighbor bootstrap info */
 int pg_qps_to_rts(pg_handle *handle, const qp_boot boots[2]);
 
+/* Update data window with application-provided buffers */
+int pg_set_window(pg_handle *handle, void *sendbuf, void *recvbuf,
+                  size_t bytes);
+
 #endif /* PG_H */


### PR DESCRIPTION
## Summary
- add `pg_create` to initialize verbs resources and query inline cap
- add `pg_destroy` for cleanup
- expose new creation/destruction APIs in header