### PR TITLE
Implement pg_close teardown and add unit test

### DIFF
--- a/pg.h
+++ b/pg.h
@@ -136,6 +136,8 @@ int pg_world_size(const pg_handle *handle);
 /* Create and destroy a process group handle */
 pg_handle *pg_create(int rank, int world_size, size_t chunk_bytes,
                      int inflight_limit);
+void pg_close(pg_handle *handle);
+/* Backwards compatible name */
 void pg_destroy(pg_handle *handle);
 
 /* QP bootstrap information exchanged with neighbors */

--- a/pg_close_test.c
+++ b/pg_close_test.c
@@ -1,0 +1,62 @@
+#include "pg.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+struct ibv_context { int dummy; };
+struct ibv_pd { int dummy; };
+struct ibv_cq { int dummy; };
+struct ibv_qp { int dummy; };
+struct ibv_mr { int dummy; };
+
+static int destroy_qp_calls = 0;
+static int destroy_cq_calls = 0;
+static int dereg_mr_calls = 0;
+static int dealloc_pd_calls = 0;
+static int close_dev_calls = 0;
+
+int ibv_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc) {
+    (void)cq; (void)num_entries; (void)wc; return 0;
+}
+int ibv_destroy_qp(struct ibv_qp *qp) { (void)qp; destroy_qp_calls++; return 0; }
+int ibv_destroy_cq(struct ibv_cq *cq) { (void)cq; destroy_cq_calls++; return 0; }
+int ibv_dereg_mr(struct ibv_mr *mr) { (void)mr; dereg_mr_calls++; return 0; }
+int ibv_dealloc_pd(struct ibv_pd *pd) { (void)pd; dealloc_pd_calls++; return 0; }
+int ibv_close_device(struct ibv_context *ctx) { (void)ctx; close_dev_calls++; return 0; }
+
+int main(void) {
+    pg_handle *h = calloc(1, sizeof(pg_handle));
+    assert(h);
+
+    struct ibv_qp qp; struct ibv_cq cq; struct ibv_mr mr1; struct ibv_mr mr_ctrl;
+    struct ibv_pd pd; struct ibv_context ctx;
+
+    h->qps[0] = &qp; /* only one QP to destroy */
+    h->cq = &cq;
+    h->data_mrs[0] = &mr1;
+    h->ctrl_mr = &mr_ctrl;
+    h->pd = &pd;
+    h->ctx = &ctx;
+    h->bootstrap_socks[0] = -1;
+    h->bootstrap_socks[1] = -1;
+
+    pg_close(h);
+
+    assert(destroy_qp_calls == 1);
+    assert(destroy_cq_calls == 1);
+    assert(dereg_mr_calls == 2); /* data + ctrl */
+    assert(dealloc_pd_calls == 1);
+    assert(close_dev_calls == 1);
+
+    /* closing NULL handle should be a no-op */
+    pg_close(NULL);
+    assert(destroy_qp_calls == 1);
+
+    /* zero-initialized handle should also be safe */
+    pg_handle *h2 = calloc(1, sizeof(pg_handle));
+    pg_close(h2);
+    assert(destroy_qp_calls == 1);
+
+    printf("pg_close tests passed\n");
+    return 0;
+}

--- a/pg_control_test.c
+++ b/pg_control_test.c
@@ -2,10 +2,19 @@
 #include <assert.h>
 #include <stdio.h>
 
+struct ibv_context { int dummy; };
+struct ibv_pd { int dummy; };
 struct ibv_cq { int dummy; };
+struct ibv_qp { int dummy; };
+struct ibv_mr { int dummy; };
 int ibv_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc) {
     (void)cq; (void)num_entries; (void)wc; return 0;
 }
+int ibv_destroy_qp(struct ibv_qp *qp) { (void)qp; return 0; }
+int ibv_destroy_cq(struct ibv_cq *cq) { (void)cq; return 0; }
+int ibv_dereg_mr(struct ibv_mr *mr) { (void)mr; return 0; }
+int ibv_dealloc_pd(struct ibv_pd *pd) { (void)pd; return 0; }
+int ibv_close_device(struct ibv_context *ctx) { (void)ctx; return 0; }
 
 int main(void) {
     /* verify packed sizes */

--- a/pg_cq_poll_test.c
+++ b/pg_cq_poll_test.c
@@ -3,7 +3,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+struct ibv_context { int dummy; };
+struct ibv_pd { int dummy; };
 struct ibv_cq { int dummy; };
+struct ibv_qp { int dummy; };
+struct ibv_mr { int dummy; };
 
 static int poll_called = 0;
 int ibv_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc) {
@@ -20,6 +24,11 @@ int ibv_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc) {
     }
     return 0;
 }
+int ibv_destroy_qp(struct ibv_qp *qp) { (void)qp; return 0; }
+int ibv_destroy_cq(struct ibv_cq *cq) { (void)cq; return 0; }
+int ibv_dereg_mr(struct ibv_mr *mr) { (void)mr; return 0; }
+int ibv_dealloc_pd(struct ibv_pd *pd) { (void)pd; return 0; }
+int ibv_close_device(struct ibv_context *ctx) { (void)ctx; return 0; }
 
 int main(void) {
     struct ibv_cq cq;

--- a/pg_sendrecv_inline_test.c
+++ b/pg_sendrecv_inline_test.c
@@ -3,13 +3,22 @@
 #include <stdio.h>
 #include <string.h>
 
+struct ibv_context { int dummy; };
+struct ibv_pd { int dummy; };
 struct ibv_cq { int dummy; };
+struct ibv_qp { int dummy; };
+struct ibv_mr { int dummy; };
 int ibv_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc) {
     (void)cq; (void)num_entries;
     wc[0].status = IBV_WC_SUCCESS;
     wc[0].wr_id = 0;
     return 1;
 }
+int ibv_destroy_qp(struct ibv_qp *qp) { (void)qp; return 0; }
+int ibv_destroy_cq(struct ibv_cq *cq) { (void)cq; return 0; }
+int ibv_dereg_mr(struct ibv_mr *mr) { (void)mr; return 0; }
+int ibv_dealloc_pd(struct ibv_pd *pd) { (void)pd; return 0; }
+int ibv_close_device(struct ibv_context *ctx) { (void)ctx; return 0; }
 
 int main(void) {
     pg_handle handle = {0};


### PR DESCRIPTION
## Summary
- add pg_close to safely destroy QPs, CQ, MRs, PD, and device context
- close bootstrap sockets and free handle; provide pg_destroy wrapper
- add pg_close unit test and update existing tests for new stubs

## Testing
- `gcc -std=c11 -Wall pg_close_test.c pg.c -o pg_close_test && ./pg_close_test`
- `gcc -std=c11 -Wall bootstrap_test.c bootstrap.c ring.c -o bootstrap_test && ./bootstrap_test`
- `gcc -std=c11 -Wall chunk_planner_test.c chunk_planner.c -o chunk_planner_test && ./chunk_planner_test`
- `gcc -std=c11 -Wall pg_control_test.c pg.c -o pg_control_test && ./pg_control_test`
- `gcc -std=c11 -Wall pg_cq_poll_test.c pg.c -o pg_cq_poll_test && ./pg_cq_poll_test`
- `gcc -std=c11 -Wall pg_sendrecv_inline_test.c pg.c -o pg_sendrecv_inline_test && ./pg_sendrecv_inline_test`
- `gcc -std=c11 -Wall read_engine_test.c read_engine.c -o read_engine_test && ./read_engine_test`
- `gcc -std=c11 -Wall reduce_test.c reduce.c -o reduce_test && ./reduce_test`
- `gcc -std=c11 -Wall ring_test.c ring.c -o ring_test && ./ring_test`
- `gcc -std=c11 -Wall rtscts_test.c rtscts.c read_engine.c -o rtscts_test && ./rtscts_test`
- `gcc -std=c11 -Wall serverlist_test.c serverlist.c -o serverlist_test && ./serverlist_test`


------
https://chatgpt.com/codex/tasks/task_e_68a8cea544ec8332a7b1d2ccee894a0b